### PR TITLE
Use register_assert_rewrite at root for step assertion errors

### DIFF
--- a/src/tursu/entrypoints/cli.py
+++ b/src/tursu/entrypoints/cli.py
@@ -5,7 +5,13 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-DEFAULT_INIT = '''\
+DEFAULT_TESTS_INIT = """\
+import pytest
+
+pytest.register_assert_rewrite("tests.functionals")
+"""
+
+DEFAULT_FUNCTIONAL_INIT = '''\
 """
 Functional tests suite based on Turşu.
 
@@ -122,15 +128,17 @@ def init(outdir: str, overwrite: bool, no_dummies: bool) -> None:
     if outpath.is_file():
         outpath.unlink()
 
-    outpath.mkdir(exist_ok=True, parents=True)
-    (outpath / "__init__.py").write_text(DEFAULT_INIT)
-    (outpath / "conftest.py").write_text(
+    (outpath / "functionals").mkdir(exist_ok=True, parents=True)
+    (outpath / "__init__.py").write_text(DEFAULT_TESTS_INIT)
+    tests_outpath = outpath / "functionals"
+    (tests_outpath / "__init__.py").write_text(DEFAULT_FUNCTIONAL_INIT)
+    (tests_outpath / "conftest.py").write_text(
         DEFAULT_CONFTEST_WITH_DUMMIES if with_dummies else DEFAULT_CONFTEST
     )
 
     if with_dummies:
-        (outpath / "steps.py").write_text(DEFAULT_STEPS)
-        (outpath / "login.feature").write_text(DEFAULT_FEATURE)
+        (tests_outpath / "steps.py").write_text(DEFAULT_STEPS)
+        (tests_outpath / "login.feature").write_text(DEFAULT_FEATURE)
 
 
 def main(args: Sequence[str] = sys.argv) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("tests.functionals")

--- a/tests/unittests/entrypoints/test_entrypoint.py
+++ b/tests/unittests/entrypoints/test_entrypoint.py
@@ -24,10 +24,12 @@ def test_main_replace_file(tmp_path: Path):
     (tmp_path / "tursu").write_text("dummy")
     main(["tursu", "init", "-o", str(tmp_path / "tursu"), "--overwrite"])
     files = {f.name: f.read_text() for f in tmp_path.glob("tursu/*.py")}
+    assert set(files.keys()) == {"__init__.py"}
+    files = {f.name: f.read_text() for f in tmp_path.glob("tursu/functionals/*.py")}
     assert set(files.keys()) == {"__init__.py", "conftest.py", "steps.py"}
 
 
 def test_main_no_dummies(tmp_path: Path):
     main(["tursu", "init", "-o", str(tmp_path / "tursu"), "--no-dummies"])
-    files = {f.name: f.read_text() for f in tmp_path.glob("tursu/*.py")}
+    files = {f.name: f.read_text() for f in tmp_path.glob("tursu/functionals/*.py")}
     assert set(files.keys()) == {"__init__.py", "conftest.py"}


### PR DESCRIPTION
Change functionals tests layout to get assertion from steps properly displayed.