### PR TITLE
Don't write tests to disk while using vvv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ FAILED tests/functionals/login.feature::test_3_User_can_login - tursu.runner.Sce
 
 ```{note}
 
-If --trace is used, or -vvv, the tests files are written on the disk, and
+If --trace is used, the tests files are written on the disk, and
 the `???` in the context are replaced by the generated python test function.
 
 This may be usefull in case of hard time debugging.

--- a/src/tursu/entrypoints/plugin.py
+++ b/src/tursu/entrypoints/plugin.py
@@ -67,10 +67,7 @@ class GherkinTestModule(pytest.Module):
 
         self.test_casefile = path.parent / case.filename
         super().__init__(path=self.test_casefile, parent=parent, **kwargs)
-        if (
-            self.session.config.getoption("--trace")
-            or self.session.config.option.verbose == 3
-        ):
+        if self.session.config.getoption("--trace"):
             case.write_temporary(path.parent)  # coverage: ignore
             # we preload before updating the path
             self._obj = super()._getobj()  # coverage: ignore


### PR DESCRIPTION
Using --trace is ok for debuging only